### PR TITLE
feat: 홈페이지 대쉬보드 & 메뉴 선택 기능 추가

### DIFF
--- a/src/Layout/DefaultLayout.css
+++ b/src/Layout/DefaultLayout.css
@@ -6,6 +6,4 @@
   flex: 1;
   height: 100vh;
   display: flex;
-  justify-content: center;
-  align-items: center;
 }

--- a/src/components/dashboard/DashBoard.css
+++ b/src/components/dashboard/DashBoard.css
@@ -1,0 +1,76 @@
+.dashboard-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.league-title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 6px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 6px;
+  max-width: 800px;
+  min-width: 600px;
+}
+
+th,
+td {
+  padding: 12px;
+  text-align: center;
+  border-bottom: 1px solid #ddd;
+}
+
+th {
+  background-color: #f8f9fa;
+  font-weight: bold;
+}
+
+.dashboard-line:hover {
+  background-color: #83807b;
+  cursor: pointer;
+  color: white;
+}
+
+.form-container {
+  display: flex;
+  justify-content: center;
+  gap: 2px;
+}
+
+.form-result {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  margin: 0 2px;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.win {
+  border: 2px solid #34a853;
+  color: #34a853;
+}
+
+tr:hover .win,
+tr:hover .draw,
+tr:hover .lose {
+  background-color: #f2f2f2;
+}
+
+.draw {
+  border: 2px solid #9aa0a6;
+  color: #9aa0a6;
+}
+
+.lose {
+  border: 2px solid #ea4335;
+  color: #ea4335;
+}

--- a/src/components/dashboard/DashBoard.jsx
+++ b/src/components/dashboard/DashBoard.jsx
@@ -1,0 +1,138 @@
+import "./DashBoard.css";
+
+const dashboardMockData = {
+  league: "프리미어 리그",
+  teams: [
+    {
+      name: "리버풀",
+      rank: "1",
+      points: "60",
+      played: "25",
+      win: "18",
+      draw: "6",
+      lose: "1",
+      goals: {
+        for: "60",
+        against: "24",
+      },
+      form: "WDWWW",
+    },
+    {
+      name: "아스널",
+      rank: "2",
+      points: "53",
+      played: "25",
+      win: "15",
+      draw: "8",
+      lose: "2",
+      goals: {
+        for: "51",
+        against: "22",
+      },
+      form: "WWWDW",
+    },
+    {
+      name: "노팅엄 포레스트",
+      rank: "3",
+      points: "47",
+      played: "25",
+      win: "14",
+      draw: "5",
+      lose: "6",
+      goals: {
+        for: "41",
+        against: "29",
+      },
+      form: "LWLWD",
+    },
+    {
+      name: "맨체스터 시티",
+      rank: "4",
+      points: "44",
+      played: "25",
+      win: "13",
+      draw: "5",
+      lose: "7",
+      goals: {
+        for: "52",
+        against: "35",
+      },
+      form: "WLWWD",
+    },
+    {
+      name: "본머스",
+      rank: "5",
+      points: "43",
+      played: "25",
+      win: "12",
+      draw: "7",
+      lose: "6",
+      goals: {
+        for: "44",
+        against: "29",
+      },
+      form: "WLWWD",
+    },
+  ],
+};
+
+const DashBoard = () => {
+  return (
+    <div className="dashboard-container">
+      <span className="league-title">{dashboardMockData.league}</span>
+      <table>
+        <thead>
+          <tr>
+            <th>순위</th>
+            <th>팀명</th>
+            <th>승점</th>
+            <th>경기</th>
+            <th>승</th>
+            <th>무</th>
+            <th>패</th>
+            <th>득점</th>
+            <th>실점</th>
+            <th>득실</th>
+            <th>최근 5경기</th>
+          </tr>
+        </thead>
+        <tbody>
+          {dashboardMockData.teams.map((team) => (
+            <tr className="dashboard-line" key={team.rank}>
+              <td>{team.rank}</td>
+              <td>{team.name}</td>
+              <td>{team.points}</td>
+              <td>{team.played}</td>
+              <td>{team.win}</td>
+              <td>{team.draw}</td>
+              <td>{team.lose}</td>
+              <td>{team.goals.for}</td>
+              <td>{team.goals.against}</td>
+              <td>{Number(team.goals.for) - Number(team.goals.against)}</td>
+              <td>
+                <div className="form-container">
+                  {team.form.split("").map((result, index) => (
+                    <span
+                      key={index}
+                      className={`form-result ${
+                        result === "W"
+                          ? "win"
+                          : result === "D"
+                            ? "draw"
+                            : "lose"
+                      }`}
+                    >
+                      {result}
+                    </span>
+                  ))}
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default DashBoard;

--- a/src/components/navbar/NavigationBar.css
+++ b/src/components/navbar/NavigationBar.css
@@ -1,7 +1,7 @@
 .navigation-bar-container {
   width: 6rem;
-  max-width: 100px;
-  min-width: 80px;
+  max-width: 70px;
+  min-width: 70px;
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/src/pages/home/Home.css
+++ b/src/pages/home/Home.css
@@ -1,2 +1,7 @@
 .home-container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+  flex-direction: column;
 }

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,6 +1,25 @@
+import { useState } from "react";
+import DashBoard from "../../components/dashboard/DashBoard";
 import "./Home.css";
+import SelectMenu from "./view/SelectMenu";
 const Home = () => {
-  return <div className="home-container">메인 컨텐츠</div>;
+  const [selectedTab, setSelectedTab] = useState([]);
+
+  const toggleSelectTab = (clickedTab) => {
+    setSelectedTab((prev) =>
+      prev.includes(clickedTab)
+        ? prev.filter((tab) => tab !== clickedTab)
+        : [...prev, clickedTab]
+    );
+  };
+
+  return (
+    <div className="home-container">
+      <SelectMenu toggleSelectTab={toggleSelectTab} selectedTab={selectedTab} />
+      {(selectedTab.includes("팀 뉴스") ||
+        selectedTab.includes("경기 뉴스")) && <DashBoard />}
+    </div>
+  );
 };
 
 export default Home;

--- a/src/pages/home/view/SelectMenu.css
+++ b/src/pages/home/view/SelectMenu.css
@@ -1,0 +1,25 @@
+.select-menu-tab {
+  padding: 6px 10px;
+  border-radius: 12px;
+  border: 1px solid gray;
+  text-align: center;
+  font-weight: bold;
+}
+
+.select-menu-tab:hover {
+  background-color: rgb(122, 106, 87);
+  color: white;
+  cursor: pointer;
+}
+
+.select-menu-container {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.active {
+  background-color: rgb(122, 106, 87);
+  color: white;
+}

--- a/src/pages/home/view/SelectMenu.jsx
+++ b/src/pages/home/view/SelectMenu.jsx
@@ -1,0 +1,37 @@
+import PropTypes from "prop-types";
+import "./SelectMenu.css";
+
+const SelectMenu = ({ toggleSelectTab, selectedTab }) => {
+  console.log(selectedTab);
+  return (
+    <div className="select-menu-container">
+      <div
+        className={`select-menu-tab ${selectedTab.includes("리그 뉴스") ? "active" : ""}`}
+        onClick={() => {
+          toggleSelectTab("리그 뉴스");
+        }}
+      >
+        리그 뉴스
+      </div>
+      <div
+        className={`select-menu-tab ${selectedTab.includes("팀 뉴스") ? "active" : ""}`}
+        onClick={() => toggleSelectTab("팀 뉴스")}
+      >
+        팀 뉴스
+      </div>
+      <div
+        className={`select-menu-tab ${selectedTab.includes("경기 뉴스") ? "active" : ""}`}
+        onClick={() => toggleSelectTab("경기 뉴스")}
+      >
+        경기 뉴스
+      </div>
+    </div>
+  );
+};
+
+SelectMenu.propTypes = {
+  toggleSelectTab: PropTypes.func.isRequired,
+  selectedTab: PropTypes.array.isRequired,
+};
+
+export default SelectMenu;


### PR DESCRIPTION

<img width="1347" alt="스크린샷 2025-02-18 오후 10 23 21" src="https://github.com/user-attachments/assets/fb613e85-78a8-41de-bdac-e928d25a843e" />

팀 뉴스 & 경기 뉴스 클릭시 대쉬보드 확인 가능

프롬프트 영역 추가 + 클릭된 내용 프롬프트에 추가하는 기능 구현 예정
